### PR TITLE
Add support for time as timestamp

### DIFF
--- a/src/irclog2html/irclog2html.py
+++ b/src/irclog2html/irclog2html.py
@@ -165,7 +165,7 @@ class LogParser(object):
             if time is None:
                 m = self.TIMESTAMP_REGEXP.match(line)
                 if m:
-                    time = datetime.datetime.fromtimestamp(
+                    time = datetime.datetime.utcfromtimestamp(
                         int(m.group(1))).isoformat()
                     line = line[len(m.group(0)):]
 

--- a/src/irclog2html/irclog2html.py
+++ b/src/irclog2html/irclog2html.py
@@ -56,6 +56,7 @@ import re
 import shlex
 import shutil
 import sys
+import datetime
 
 try:
     from urllib import quote
@@ -119,6 +120,7 @@ class LogParser(object):
         r'(?:\d{4}-\d{2}-\d{2}T|\d{2}-\w{3}-\d{4} |\w{3} \d{2} |\d{2} \w{3} )?' # Optional date
         r'\d\d:\d\d(:\d\d)?' # Mandatory HH:MM, optional :SS
         r')\]? +') # Optional ], mandatory space
+    TIMESTAMP_REGEXP = re.compile(r'^(\d*) +')
     NICK_REGEXP = re.compile(r'^<(.*?)(!.*?)?>\s')
     DIRCPROXY_NICK_REGEXP = re.compile(r'^<(.*?)(!.*)?>\s[\+-]?')
     JOIN_REGEXP = re.compile(r'^(?:\*\*\*|-->)\s.*joined')
@@ -159,6 +161,13 @@ class LogParser(object):
                 line = line[len(m.group(0)):]
             else:
                 time = None
+
+            if time is None:
+                m = self.TIMESTAMP_REGEXP.match(line)
+                if m:
+                    time = datetime.datetime.fromtimestamp(
+                        int(m.group(1))).strftime('%H:%m')
+                    line = line[len(m.group(0)):]
 
             m = self.NICK_REGEXP.match(line)
             if m:

--- a/src/irclog2html/irclog2html.py
+++ b/src/irclog2html/irclog2html.py
@@ -120,7 +120,7 @@ class LogParser(object):
         r'(?:\d{4}-\d{2}-\d{2}T|\d{2}-\w{3}-\d{4} |\w{3} \d{2} |\d{2} \w{3} )?' # Optional date
         r'\d\d:\d\d(:\d\d)?' # Mandatory HH:MM, optional :SS
         r')\]? +') # Optional ], mandatory space
-    TIMESTAMP_REGEXP = re.compile(r'^(\d*) +')
+    TIMESTAMP_REGEXP = re.compile(r'^(\d+) +')
     NICK_REGEXP = re.compile(r'^<(.*?)(!.*?)?>\s')
     DIRCPROXY_NICK_REGEXP = re.compile(r'^<(.*?)(!.*)?>\s[\+-]?')
     JOIN_REGEXP = re.compile(r'^(?:\*\*\*|-->)\s.*joined')
@@ -166,7 +166,7 @@ class LogParser(object):
                 m = self.TIMESTAMP_REGEXP.match(line)
                 if m:
                     time = datetime.datetime.fromtimestamp(
-                        int(m.group(1))).strftime('%H:%m')
+                        int(m.group(1))).isoformat()
                     line = line[len(m.group(0)):]
 
             m = self.NICK_REGEXP.match(line)

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -92,7 +92,7 @@ def doctest_LogParser():
         >>> test('[15 Jan 08:42] <mg> +++Hello+++')
         '15 Jan 08:42' COMMENT ('mg', '+++Hello+++')
         >>> test('1075917300 <mg> Hello!')
-        '2004-02-04T18:55:00' COMMENT ('mg', 'Hello!')
+        '2004-02-04T17:55:00' COMMENT ('mg', 'Hello!')
 
     Excessive metainformation is stripped from nicknames
 

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -91,6 +91,8 @@ def doctest_LogParser():
         '02-Feb-2004 14:18:55' COMMENT ('mg', 'Hello!')
         >>> test('[15 Jan 08:42] <mg> +++Hello+++')
         '15 Jan 08:42' COMMENT ('mg', '+++Hello+++')
+        >>> test('1075917300 <mg> Hello!')
+        '2004-02-04T18:55:00' COMMENT ('mg', 'Hello!')
 
     Excessive metainformation is stripped from nicknames
 


### PR DESCRIPTION
I use the log from [ii](https://tools.suckless.org/ii/) which switched to timestamp format for the log.