### PR TITLE
setup.py: fix UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import re
+from io import open
 from setuptools import setup
 
 
@@ -8,7 +9,7 @@ here = os.path.dirname(__file__)
 
 
 def read(filename):
-    with open(os.path.join(here, filename)) as f:
+    with open(os.path.join(here, filename), encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
```
I: pybuild base:184: python3.6 setup.py clean
Traceback (most recent call last):
  File "setup.py", line 15, in <module>
    long_description = read('README.rst') + '\n\n' + read('CHANGES.rst')
  File "setup.py", line 12, in read
    return f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 213: ordinal not in range(128)
```

This should be compatible with both python2 and python3.