### PR TITLE
remove Python 2 crumbs

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -22,8 +22,8 @@ import os
 import shutil
 import sys
 import tempfile
-
 from optparse import OptionParser
+
 
 __version__ = '2015-07-01'
 # See zc.buildout's changelog if this version is up to date.
@@ -96,6 +96,7 @@ if not options.allow_site_packages:
     # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
+
     # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
@@ -115,8 +116,9 @@ if options.setuptools_to_dir is not None:
     setup_args['to_dir'] = options.setuptools_to_dir
 
 ez['use_setuptools'](**setup_args)
-import setuptools
 import pkg_resources
+import setuptools
+
 
 # This does not (always?) update the default working set.  We will
 # do it.
@@ -188,6 +190,8 @@ if version:
 cmd.append(requirement)
 
 import subprocess
+
+
 if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
@@ -198,6 +202,7 @@ if subprocess.call(cmd) != 0:
 ws.add_entry(tmpeggs)
 ws.require(requirement)
 import zc.buildout.buildout
+
 
 if not [a for a in args if '=' not in a]:
     args.append('bootstrap')

--- a/porting/test.py
+++ b/porting/test.py
@@ -52,7 +52,7 @@ def run_in_tempdir(inputfile, script, args):
         outfilename = newinputfile + '.html'
         try:
             return open(outfilename).read().replace(dir, '/tmpdir')
-        except IOError, e:
+        except IOError as e:
             raise AssertionError('%s did not create the output file\n%s' %
                                  (cmdline, e))
     finally:
@@ -95,30 +95,30 @@ DEFAULT_ARGS = ('-s table', '-s simplett', '-s tt', '-s simpletable',
 
 def testcase(inputfile, args_to_try=DEFAULT_ARGS):
     """Run both scripts on inputfile with various arguments."""
-    print inputfile,
+    print(inputfile),
     try:
         for args in args_to_try:
-            print ".",
+            print(".", end='')
             run_and_compare(inputfile, args)
-    except AssertionError, e:
-        print "FAILED"
-        print
-        print e
-        print
+    except AssertionError as e:
+        print("FAILED")
+        print()
+        print(e)
+        print()
     else:
-        print "ok"
+        print("ok")
 
 
 def main():
     os.chdir(os.path.dirname(__file__))
     # the Perl script takes ages to process dircproxy-example.log; ignore it
     testcases = glob.glob('testcases/test*.log')
-    print "Comparing outputs produced by the Perl version and the Python port"
-    print "There are %d test cases" % len(testcases)
+    print("Comparing outputs produced by the Perl version and the Python port")
+    print("There are %d test cases" % len(testcases))
     n = 0
     for inputfile in testcases:
         n += 1
-        print n,
+        print(n, end='')
         testcase(inputfile)
 
 

--- a/porting/test.py
+++ b/porting/test.py
@@ -5,13 +5,13 @@ Functional tests for irclog2html.py
 You must run this script in a directory that contains irclog2html.py,
 irclog2html.pl and testcases/*.log.  Both scripts must be executable.
 """
-import os
-import tempfile
-import shutil
 import difflib
 import glob
+import os
+import shutil
+import tempfile
 
-from irclog2html import VERSION, RELEASE
+from irclog2html import RELEASE, VERSION
 
 
 def replace(s, replacements):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     python_requires='>=3.7',
     keywords='irc log colorizer html wsgi',
     extras_require=dict(test=[
-        "mock",
         "zope.testing",
     ]),
     packages=['irclog2html'],

--- a/src/irclog2html/irclog2html.py
+++ b/src/irclog2html/irclog2html.py
@@ -45,8 +45,6 @@ was written by Jeff Waugh and is available at www.perkypants.org
 #   New default style: xhtmltable
 #
 
-from __future__ import print_function, unicode_literals
-
 import datetime
 import gzip
 import io
@@ -58,23 +56,11 @@ import re
 import shlex
 import shutil
 import sys
-
-
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
+from urllib.parse import quote
 
 from ._version import __date__ as RELEASE
 from ._version import __homepage__ as HOMEPAGE
 from ._version import __version__ as VERSION
-
-
-try:
-    unicode
-except NameError:
-    # Python 3.x
-    unicode = str
 
 
 # If someone packages this for a Linux distro, they'll want to patch this to
@@ -145,7 +131,7 @@ class LogParser(object):
         Supports xchat's hybrid Latin/Unicode encoding, as documented here:
         http://xchat.org/encoding/
         """
-        if isinstance(s, unicode):
+        if isinstance(s, str):
             # Accept input that's already Unicode, for convenience
             return s
         try:

--- a/src/irclog2html/irclogsearch.py
+++ b/src/irclog2html/irclogsearch.py
@@ -22,8 +22,6 @@ Apache configuration example:
 # Released under the terms of the GNU GPL v2 or v3
 # https://www.gnu.org/copyleft/gpl.html
 
-from __future__ import print_function, unicode_literals
-
 import cgi
 import cgitb
 import io
@@ -32,12 +30,7 @@ import re
 import sys
 import time
 from contextlib import closing
-
-
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
+from urllib.parse import quote
 
 from .irclog2html import (
     HOMEPAGE,
@@ -51,12 +44,6 @@ from .irclog2html import (
 )
 from .logs2html import find_log_files
 
-
-try:
-    unicode
-except NameError:
-    # Python 3.x
-    unicode = str
 
 
 DEFAULT_LOGFILE_PATH = os.path.dirname(__file__)
@@ -172,7 +159,7 @@ def search_irc_logs(query, stats=None, where=DEFAULT_LOGFILE_PATH,
             elif event == LogParser.NICKCHANGE:
                 text, oldnick, newnick = info
             else:
-                text = unicode(info)
+                text = str(info)
             stats.lines += 1
             if query in text.lower():
                 stats.matches += 1

--- a/src/irclog2html/irclogsearch.py
+++ b/src/irclog2html/irclogsearch.py
@@ -45,7 +45,6 @@ from .irclog2html import (
 from .logs2html import find_log_files
 
 
-
 DEFAULT_LOGFILE_PATH = os.path.dirname(__file__)
 DEFAULT_LOGFILE_PATTERN = "*.log"
 

--- a/src/irclog2html/irclogserver.py
+++ b/src/irclog2html/irclogserver.py
@@ -25,8 +25,6 @@ Apache configuration example:
 # Released under the terms of the GNU GPL v2 or v3
 # https://www.gnu.org/copyleft/gpl.html
 
-from __future__ import print_function
-
 import argparse
 import cgi
 import datetime
@@ -34,13 +32,8 @@ import io
 import os
 import time
 from operator import attrgetter
+from urllib.parse import quote_plus
 from wsgiref.simple_server import make_server
-
-
-try:
-    from urllib import quote_plus  # Py2
-except ImportError:
-    from urllib.parse import quote_plus  # Py3
 
 from ._version import __date__, __version__
 from .irclog2html import (

--- a/src/irclog2html/logs2html.py
+++ b/src/irclog2html/logs2html.py
@@ -11,8 +11,6 @@ Looks for *.log in a given directory.  Needs an ISO 8601 date (YYYY-MM-DD or
 YYYYMMDD) in the filename.
 """
 
-from __future__ import print_function, unicode_literals
-
 import datetime
 import glob
 import optparse
@@ -29,11 +27,7 @@ from operator import attrgetter
 # Released under the terms of the GNU GPL v2 or v3
 # https://www.gnu.org/copyleft/gpl.html
 
-
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
+from urllib.parse import quote
 
 from . import irclog2html
 from .irclog2html import HOMEPAGE, RELEASE, VERSION, escape

--- a/src/irclog2html/logs2html.py
+++ b/src/irclog2html/logs2html.py
@@ -32,8 +32,6 @@ from .irclog2html import HOMEPAGE, RELEASE, VERSION, escape
 # https://www.gnu.org/copyleft/gpl.html
 
 
-
-
 # If someone packages this for a Linux distro, they'll want to patch this to
 # something like /usr/share/irclog2html/irclog.css, I imagine
 CSS_FILE = os.path.join(os.path.dirname(__file__), 'irclog.css')

--- a/src/irclog2html/logs2html.py
+++ b/src/irclog2html/logs2html.py
@@ -19,6 +19,10 @@ import re
 import shutil
 import sys
 from operator import attrgetter
+from urllib.parse import quote
+
+from . import irclog2html
+from .irclog2html import HOMEPAGE, RELEASE, VERSION, escape
 
 
 # Copyright (c) 2005--2013  Marius Gedminas
@@ -27,10 +31,7 @@ from operator import attrgetter
 # Released under the terms of the GNU GPL v2 or v3
 # https://www.gnu.org/copyleft/gpl.html
 
-from urllib.parse import quote
 
-from . import irclog2html
-from .irclog2html import HOMEPAGE, RELEASE, VERSION, escape
 
 
 # If someone packages this for a Linux distro, they'll want to patch this to

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -3,7 +3,7 @@ import io
 import os
 import shutil
 import sys
-import tmpfile
+import tempfile
 import unittest
 
 from irclog2html.irclog2html import (

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -34,7 +34,7 @@ def myrepr(o):
             return '(%s, )' % ', '.join(map(myrepr, o))
         else:
             return '(%s)' % ', '.join(map(myrepr, o))
-    elif isinstance(o, str):
+    else:
         return repr(o)
 
 

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -1,6 +1,9 @@
 import doctest
+import io
 import os
+import shutil
 import sys
+import tmpfile
 import unittest
 
 from irclog2html.irclog2html import (

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -35,8 +35,6 @@ def myrepr(o):
         else:
             return '(%s)' % ', '.join(map(myrepr, o))
     elif isinstance(o, str):
-        return repr(o).lstrip('u')
-    else:
         return repr(o)
 
 

--- a/src/irclog2html/tests/test_irclog2html.py
+++ b/src/irclog2html/tests/test_irclog2html.py
@@ -1,11 +1,6 @@
-from __future__ import print_function
-
 import doctest
-import io
 import os
-import shutil
 import sys
-import tempfile
 import unittest
 
 from irclog2html.irclog2html import (
@@ -26,13 +21,6 @@ from irclog2html.irclog2html import (
 )
 
 
-try:
-    unicode
-except NameError:
-    # Python 3.x
-    unicode = str
-
-
 here = os.path.dirname(__file__)
 
 
@@ -43,7 +31,7 @@ def myrepr(o):
             return '(%s, )' % ', '.join(map(myrepr, o))
         else:
             return '(%s)' % ', '.join(map(myrepr, o))
-    elif isinstance(o, unicode):
+    elif isinstance(o, str):
         return repr(o).lstrip('u')
     else:
         return repr(o)

--- a/src/irclog2html/tests/test_irclogsearch.py
+++ b/src/irclog2html/tests/test_irclogsearch.py
@@ -67,7 +67,7 @@ def myrepr(o):
             return '(%s, )' % ', '.join(map(myrepr, o))
         else:
             return '(%s)' % ', '.join(map(myrepr, o))
-    elif isinstance(o, str):
+    else:
         return repr(o)
 
 

--- a/src/irclog2html/tests/test_irclogsearch.py
+++ b/src/irclog2html/tests/test_irclogsearch.py
@@ -1,5 +1,3 @@
-import cgi
-import datetime
 import doctest
 import gzip
 import os
@@ -10,7 +8,6 @@ import tempfile
 import unittest
 from contextlib import closing
 
-import mock
 from zope.testing import renormalizing
 
 from irclog2html.irclogsearch import (
@@ -23,13 +20,6 @@ from irclog2html.irclogsearch import (
     search_irc_logs,
     search_page,
 )
-
-
-try:
-    unicode
-except NameError:
-    # Python 3.x
-    unicode = str
 
 
 here = os.path.dirname(__file__)
@@ -74,7 +64,7 @@ def myrepr(o):
             return '(%s, )' % ', '.join(map(myrepr, o))
         else:
             return '(%s)' % ', '.join(map(myrepr, o))
-    elif isinstance(o, unicode):
+    elif isinstance(o, str):
         return repr(o).lstrip('u')
     else:
         return repr(o)

--- a/src/irclog2html/tests/test_irclogsearch.py
+++ b/src/irclog2html/tests/test_irclogsearch.py
@@ -68,8 +68,6 @@ def myrepr(o):
         else:
             return '(%s)' % ', '.join(map(myrepr, o))
     elif isinstance(o, str):
-        return repr(o).lstrip('u')
-    else:
         return repr(o)
 
 

--- a/src/irclog2html/tests/test_irclogsearch.py
+++ b/src/irclog2html/tests/test_irclogsearch.py
@@ -1,3 +1,5 @@
+import cgi
+import datetime
 import doctest
 import gzip
 import os
@@ -7,6 +9,7 @@ import sys
 import tempfile
 import unittest
 from contextlib import closing
+from unittest import mock
 
 from zope.testing import renormalizing
 

--- a/src/irclog2html/tests/test_irclogserver.py
+++ b/src/irclog2html/tests/test_irclogserver.py
@@ -8,8 +8,7 @@ import shutil
 import tempfile
 import unittest
 from contextlib import closing
-
-import mock
+from unittest import mock
 
 from irclog2html.irclogserver import application, dir_listing, parse_path
 

--- a/src/irclog2html/xchatlogsplit.py
+++ b/src/irclog2html/xchatlogsplit.py
@@ -11,8 +11,6 @@ This is more of an example than a real script, although I have used it to
 restore some actual IRC chat log history from my xchat logs.
 """
 
-from __future__ import print_function
-
 import locale
 import os
 import re


### PR DESCRIPTION
Hi, I hope you like it.

`cgi` is being removed in Python 3.13(?), I'll look at it later

"mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards."

https://github.com/testing-cabal/mock